### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 Integration
 ===========
 
-Stand-alone device and protocol integrations for OpenRemote.
+Stand-alone device and protocol integrations for OpenRemote with Z-Way versions 1.3.x - 1.5.x .
+For later Z-Way versions use module OpenRemoteHelpers see:
+https://github.com/Z-Wave-Me/home-automation/tree/master/modules


### PR DESCRIPTION
Adapted the Readme.md to clarify that this version is compatible with the older Z-Way releases 1.3 - 1.5. Added a link to the repository of the present version of RaZ-OR, which is now called OpenRemoteHelpers